### PR TITLE
Adding real_ip_from template rendering

### DIFF
--- a/templates/site.j2
+++ b/templates/site.j2
@@ -19,6 +19,16 @@ server {
     }
 {% endfor %}
 }
+
+{% for k,v in item.server.iteritems() if k.find('set_real_ip_from') != -1 %}
+    set_real_ip_from {{ v.name }} {
+{% for x,y in v.iteritems() if x != 'name' %}
+        {{ x }} {{ y }};
+{% endfor %}
+    }
+{% endfor %}
+}
+
 {% endif %}
 
 {% if 'upstreams' in item %}

--- a/templates/site.j2
+++ b/templates/site.j2
@@ -4,13 +4,14 @@ server {
     access_log {{ nginx_log_dirname }}/{{ item.server.name }}-{{ nginx_access_log_filename }};
     error_log {{ nginx_log_dirname }}/{{ item.server.name }}-{{ nginx_error_log_filename }};
 {% endif %}
-
 {% for k,v in item.server.iteritems() %}
-{% if k.find('location') == -1 %}
+{% if ((k.find('location') == -1) and (k.find('set_real_ip_from') == -1)) %}
     {{ k }} {{ v }};
 {% endif %}
 {% endfor %}
-
+{% for k,v in item.server.iteritems() if k.find('set_real_ip_from') != -1 %}
+    set_real_ip_from {{ v }};
+{% endfor %}
 {% for k,v in item.server.iteritems() if k.find('location') != -1 %}
     location {{ v.name }} {
 {% for x,y in v.iteritems() if x != 'name' %}
@@ -19,16 +20,6 @@ server {
     }
 {% endfor %}
 }
-
-{% for k,v in item.server.iteritems() if k.find('set_real_ip_from') != -1 %}
-    set_real_ip_from {{ v.name }} {
-{% for x,y in v.iteritems() if x != 'name' %}
-        {{ x }} {{ y }};
-{% endfor %}
-    }
-{% endfor %}
-}
-
 {% endif %}
 
 {% if 'upstreams' in item %}


### PR DESCRIPTION
Following PR allows to render additional config headers used by set_real_ip_from.
Further tagging is required, for the new release of role.

Iteration of set_real_ip_from variables is similar to simplified location headers:
```
set_real_ip_from1: 0.0.0.0/0
set_real_ip_from2: 192.168.0.1/24
set_real_ip_from3: 127.0.0.1/24
```